### PR TITLE
Add ability to clear all playing tracks

### DIFF
--- a/lib/robut/plugin/rdio.rb
+++ b/lib/robut/plugin/rdio.rb
@@ -77,7 +77,7 @@ class Robut::Plugin::Rdio
           reply("I couldn't find #{words.join(" ")} on Rdio.")
         end
         
-      else words.first =~ /play|(?:un)?pause|next|restart|back/
+      else words.first =~ /play|(?:un)?pause|next|restart|back|clear/
         Server.command << words.first
       end
       

--- a/lib/robut/plugin/rdio/public/js/rdio.js
+++ b/lib/robut/plugin/rdio/public/js/rdio.js
@@ -38,6 +38,12 @@ RdioPlayer = (function () {
                  if (data[0] == "restart") {
                      element.rdio_previous();
                  }
+
+                 if(command == "clear") {
+                   element.rdio_clearQueue();
+                   element.rdio_next(true);
+                 }
+
                  
              }
          }


### PR DESCRIPTION
This minor change allows a HipChat user to clear all of the currently playing RDIO tracks.
