### PR TITLE
add "add lunch place"

### DIFF
--- a/lib/robut/plugin/lunch.rb
+++ b/lib/robut/plugin/lunch.rb
@@ -7,8 +7,7 @@ class Robut::Plugin::Lunch
     [
       "lunch? / food? - #{nick} will suggest a place to go eat",
       "#{at_nick} lunch places - lists all the lunch places #{nick} knows about",
-      "#{at_nick} new lunch place <place> - tells #{nick} about a new place to eat",
-      "#{at_nick} add lunch place <place> - tells #{nick} about a new place to eat",
+      "#{at_nick} (add|new) lunch place <place> - tells #{nick} about a new place to eat",
       "#{at_nick} remove lunch place <place> - tells #{nick} not to suggest <place> anymore"
     ]
   end


### PR DESCRIPTION
Lets people use either "new lunch place" or "add lunch place", since the latter is often mistakenly used.
