### PR TITLE
Force safe search on google images plugin by default.

### DIFF
--- a/lib/robut/plugin/google_images.rb
+++ b/lib/robut/plugin/google_images.rb
@@ -6,7 +6,7 @@ class Robut::Plugin::GoogleImages
 
   desc "image <query> - responds with the first image from a Google Images search for <query>"
   match /^image (.*)/, :sent_to_me => true do |query|
-    image = Google::Search::Image.new(:query => query).first
+    image = Google::Search::Image.new(:query => query, :safe => :active).first
 
     if image
       reply image.uri


### PR DESCRIPTION
This is supported by the google-images gem: https://github.com/visionmedia/google-search/blob/master/lib/google-search/search/mixins/safety_level.rb
