### PR TITLE
Allow pm from room context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem 'rake'
 
 group :test do
+  gem 'test-unit'
   gem 'simplecov'
   gem 'webmock'
   gem 'time-warp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
       metaclass (~> 0.0.1)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
+    power_assert (0.2.6)
     rack (1.5.2)
     rack-protection (1.5.1)
       rack
@@ -35,6 +36,8 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     stemmer (1.0.1)
+    test-unit (3.1.5)
+      power_assert
     tilt (1.4.1)
     time-warp (1.0.8)
     twss (0.0.5)
@@ -57,6 +60,7 @@ DEPENDENCIES
   rake
   robut!
   simplecov
+  test-unit
   time-warp
   twss
   webmock

--- a/lib/robut/pm.rb
+++ b/lib/robut/pm.rb
@@ -29,12 +29,4 @@ class Robut::PM < Robut::Presence
     msg.type = :chat
     connection.client.send(msg)
   end
-
-  private
-
-  # Find a jid in the roster with the given name, case-insensitively
-  def find_jid_by_name(name)
-    name = name.downcase
-    connection.roster.items.detect {|jid, item| item.iname.downcase == name}.first
-  end
 end

--- a/lib/robut/presence.rb
+++ b/lib/robut/presence.rb
@@ -32,4 +32,13 @@ class Robut::Presence
       end
     end
   end
+
+  private
+
+  # Find a jid in the roster with the given name, case-insensitively
+  def find_jid_by_name(name)
+    name = name.downcase
+    connection.roster.items.detect {|jid, item| item.iname.downcase == name}.first
+  end
+
 end

--- a/lib/robut/room.rb
+++ b/lib/robut/room.rb
@@ -1,4 +1,4 @@
-# Handles connections and responses to different rooms. 
+# Handles connections and responses to different rooms.
 class Robut::Room < Robut::Presence
 
   # The MUC that wraps the Jabber Chat protocol.

--- a/lib/robut/room.rb
+++ b/lib/robut/room.rb
@@ -25,7 +25,7 @@ class Robut::Room < Robut::Presence
 
   # Send +message+ to the room we're currently connected to
   def reply(message, to)
-    if to.present?
+    if !to.nil?
       unless to.kind_of?(Jabber::JID)
         to = find_jid_by_name(to)
       end

--- a/lib/robut/room.rb
+++ b/lib/robut/room.rb
@@ -25,6 +25,14 @@ class Robut::Room < Robut::Presence
 
   # Send +message+ to the room we're currently connected to
   def reply(message, to)
-    muc.send(Jabber::Message.new(muc.room, message))
+    if to.present?
+      unless to.kind_of?(Jabber::JID)
+        to = find_jid_by_name(to)
+      end
+
+      muc.send(Jabber::Message.new(to, message))
+    else
+      muc.send(Jabber::Message.new(muc.room, message))
+    end
   end
 end

--- a/lib/robut/room.rb
+++ b/lib/robut/room.rb
@@ -24,15 +24,16 @@ class Robut::Room < Robut::Presence
   end
 
   # Send +message+ to the room we're currently connected to
+  # or user if 'to' is provided.
   def reply(message, to)
-    if !to.nil?
+    if to.nil?
+      muc.send(Jabber::Message.new(muc.room, message))
+    else
       unless to.kind_of?(Jabber::JID)
         to = find_jid_by_name(to)
       end
 
       muc.send(Jabber::Message.new(to, message))
-    else
-      muc.send(Jabber::Message.new(muc.room, message))
     end
   end
 end

--- a/test/unit/room_test.rb
+++ b/test/unit/room_test.rb
@@ -48,4 +48,15 @@ class RoomTest < Test::Unit::TestCase
 
     assert_equal @room.muc.room, "#{@room.name}/#{@room.connection.config.nick}"
   end
+
+  def test_sends_pm_from_room_context
+    @room.muc = MucMock.new
+    @room.join
+
+    id = Jabber::JID.new
+
+    @room.reply("My message", id)
+
+    assert id  ==  @room.muc.messages.first.to.domain
+  end
 end


### PR DESCRIPTION
The room context ignores the `to` param so you can't send private messages to users from that context. This should allow Robut to send private messages from room events.