### PR TITLE
Fixed issue with weather test in a different timezone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   # - 1.9.3
   - 2.0
   - 2.1
+  - 2.2.4
   # - jruby-18mode # JRuby in 1.8 mode
   # - jruby-19mode # JRuby in 1.9 mode
   # - rbx-18mode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     test-unit (3.1.5)
       power_assert
     tilt (1.4.1)
-    time-warp (1.0.8)
+    time-warp (1.0.15)
     twss (0.0.5)
       classifier (= 1.3.1)
     webmock (1.6.4)
@@ -66,4 +66,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,5 @@
+{<img src="https://travis-ci.org/justinweiss/robut.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/justinweiss/robut]
+
 = Robut
 
 The friendly plugin-enabled HipChat bot.

--- a/Rakefile
+++ b/Rakefile
@@ -25,3 +25,6 @@ Rake::RDocTask.new do |rd|
   rd.rdoc_dir = 'doc'
 end
 
+task :console do
+  exec "irb -r robut -I ./lib"
+end

--- a/lib/robut/plugin/weather.rb
+++ b/lib/robut/plugin/weather.rb
@@ -18,7 +18,7 @@ class Robut::Plugin::Weather
       "#{at_nick} weather <location> Tuesday - returns the weather for <location> Tuesday"
     ]
   end
-  
+
   def handle(time, sender_nick, message)
     # ignore messages that don't end in ?
     return unless message[message.length - 1, 1] == "?"

--- a/test/fixtures/seattle.xml
+++ b/test/fixtures/seattle.xml
@@ -1,1 +1,50 @@
-<?xml version="1.0"?><xml_api_reply version="1"><weather module_id="0" tab_id="0" mobile_row="0" mobile_zipped="1" row="0" section="0" ><forecast_information><city data="Seattle, WA"/><postal_code data="Seattle"/><latitude_e6 data=""/><longitude_e6 data=""/><forecast_date data="2011-05-23"/><current_date_time data="2011-05-23 22:52:57 +0000"/><unit_system data="US"/></forecast_information><current_conditions><condition data="Mostly Cloudy"/><temp_f data="58"/><temp_c data="14"/><humidity data="Humidity: 45%"/><icon data="/ig/images/weather/mostly_cloudy.gif"/><wind_condition data="Wind: E at 7 mph"/></current_conditions><forecast_conditions><day_of_week data="Mon"/><low data="48"/><high data="59"/><icon data="/ig/images/weather/partly_cloudy.gif"/><condition data="Partly Cloudy"/></forecast_conditions><forecast_conditions><day_of_week data="Tue"/><low data="51"/><high data="67"/><icon data="/ig/images/weather/partly_cloudy.gif"/><condition data="Partly Cloudy"/></forecast_conditions><forecast_conditions><day_of_week data="Wed"/><low data="49"/><high data="61"/><icon data="/ig/images/weather/rain.gif"/><condition data="Showers"/></forecast_conditions><forecast_conditions><day_of_week data="Thu"/><low data="49"/><high data="57"/><icon data="/ig/images/weather/rain.gif"/><condition data="Showers"/></forecast_conditions></weather></xml_api_reply>
+<?xml version="1.0" encoding="UTF-8"?>
+<xml_api_reply version="1">
+   <weather module_id="0" tab_id="0" mobile_row="0" mobile_zipped="1" row="0" section="0">
+      <forecast_information>
+         <city data="Seattle, WA" />
+         <postal_code data="Seattle" />
+         <latitude_e6 data="" />
+         <longitude_e6 data="" />
+         <forecast_date data="2011-05-23" />
+         <current_date_time data="2011-05-23 22:52:57 +0000" />
+         <unit_system data="US" />
+      </forecast_information>
+      <current_conditions>
+         <condition data="Mostly Cloudy" />
+         <temp_f data="58" />
+         <temp_c data="14" />
+         <humidity data="Humidity: 45%" />
+         <icon data="/ig/images/weather/mostly_cloudy.gif" />
+         <wind_condition data="Wind: E at 7 mph" />
+      </current_conditions>
+      <forecast_conditions>
+         <day_of_week data="Mon" />
+         <low data="48" />
+         <high data="59" />
+         <icon data="/ig/images/weather/partly_cloudy.gif" />
+         <condition data="Partly Cloudy" />
+      </forecast_conditions>
+      <forecast_conditions>
+         <day_of_week data="Tue" />
+         <low data="51" />
+         <high data="67" />
+         <icon data="/ig/images/weather/partly_cloudy.gif" />
+         <condition data="Partly Cloudy" />
+      </forecast_conditions>
+      <forecast_conditions>
+         <day_of_week data="Wed" />
+         <low data="49" />
+         <high data="61" />
+         <icon data="/ig/images/weather/rain.gif" />
+         <condition data="Showers" />
+      </forecast_conditions>
+      <forecast_conditions>
+         <day_of_week data="Thu" />
+         <low data="49" />
+         <high data="57" />
+         <icon data="/ig/images/weather/rain.gif" />
+         <condition data="Showers" />
+      </forecast_conditions>
+   </weather>
+</xml_api_reply>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,5 @@ require 'mocks/connection_mock'
 Robut::ConnectionMock.configure do |config|
   config.nick = "Robut t. Robot"
   config.mention_name = "robut"
+  config.on_join_message = "Good morning vietnam!!"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,5 +6,4 @@ require 'mocks/connection_mock'
 Robut::ConnectionMock.configure do |config|
   config.nick = "Robut t. Robot"
   config.mention_name = "robut"
-  config.on_join_message = "Good morning vietnam!!"
 end

--- a/test/unit/plugin/weather_test.rb
+++ b/test/unit/plugin/weather_test.rb
@@ -51,7 +51,7 @@ class Robut::Plugin::WeatherTest < Test::Unit::TestCase
   def test_handle_day
     stub_request(:any, "http://www.google.com/ig/api?weather=Seattle").to_return(:body => File.open(File.expand_path("../../../fixtures/seattle.xml", __FILE__), "r").read)
 
-    pretend_now_is(2011,"may",23,17) do
+    pretend_now_is(Time.parse("2011/05/23 17:00")) do
       @plugin.handle(Time.now, "John", "Seattle weather tuesday?")
       assert_equal( ["Forecast for Seattle, WA on Tue: Partly Cloudy, High: 67F, Low: 51F"], @plugin.reply_to.replies )
     end
@@ -60,7 +60,7 @@ class Robut::Plugin::WeatherTest < Test::Unit::TestCase
   def test_handle_tomorrow
     stub_request(:any, "http://www.google.com/ig/api?weather=Seattle").to_return(:body => File.open(File.expand_path("../../../fixtures/seattle.xml", __FILE__), "r").read)
 
-    pretend_now_is(Time.parse("23/05/2011 17:00")) do
+    pretend_now_is(Time.parse("2011/05/23 17:00")) do
       @plugin.handle(Time.now, "John", "Seattle weather tomorrow?")
       assert_equal( ["Forecast for Seattle, WA on Tue: Partly Cloudy, High: 67F, Low: 51F"], @plugin.reply_to.replies )
     end
@@ -69,7 +69,7 @@ class Robut::Plugin::WeatherTest < Test::Unit::TestCase
   def test_handle_today
     stub_request(:any, "http://www.google.com/ig/api?weather=Seattle").to_return(:body => File.open(File.expand_path("../../../fixtures/seattle.xml", __FILE__), "r").read)
 
-    pretend_now_is(Time.parse("23/05/2011 17:00")) do
+    pretend_now_is(Time.parse("2011/05/23 17:00")) do
       @plugin.handle(Time.now, "John", "Seattle weather today?")
       assert_equal( ["Forecast for Seattle, WA on Mon: Partly Cloudy, High: 59F, Low: 48F"], @plugin.reply_to.replies )
     end

--- a/test/unit/plugin/weather_test.rb
+++ b/test/unit/plugin/weather_test.rb
@@ -60,7 +60,7 @@ class Robut::Plugin::WeatherTest < Test::Unit::TestCase
   def test_handle_tomorrow
     stub_request(:any, "http://www.google.com/ig/api?weather=Seattle").to_return(:body => File.open(File.expand_path("../../../fixtures/seattle.xml", __FILE__), "r").read)
 
-    pretend_now_is(2011,"may",23,17) do
+    pretend_now_is(Time.parse("23/05/2011 17:00")) do
       @plugin.handle(Time.now, "John", "Seattle weather tomorrow?")
       assert_equal( ["Forecast for Seattle, WA on Tue: Partly Cloudy, High: 67F, Low: 51F"], @plugin.reply_to.replies )
     end
@@ -69,7 +69,7 @@ class Robut::Plugin::WeatherTest < Test::Unit::TestCase
   def test_handle_today
     stub_request(:any, "http://www.google.com/ig/api?weather=Seattle").to_return(:body => File.open(File.expand_path("../../../fixtures/seattle.xml", __FILE__), "r").read)
 
-    pretend_now_is(2011,"may",23,17) do
+    pretend_now_is(Time.parse("23/05/2011 17:00")) do
       @plugin.handle(Time.now, "John", "Seattle weather today?")
       assert_equal( ["Forecast for Seattle, WA on Mon: Partly Cloudy, High: 59F, Low: 48F"], @plugin.reply_to.replies )
     end


### PR DESCRIPTION
**What does this PR do?**
- I detected an issue whereby specs would fail when run in my time zone (Sydney/Australia).
- This was because pretend_now_is in the TimeWarp gem default to UTC, but the weather plugin uses Time.now.
- The solution was to modify the tests to explicitly specify the zone using Time.parse
- I also bumped the TimeWarp gem
- I also added the TravisCI build badge to the Readme